### PR TITLE
Allow percent sign in symbol names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ including many non standard features. Most notable of the extra
 features is the ability to extend LISP with Go code. Also included is
 a Read Eval Print Loop (REPL) that provides an environment for
 prototyping, testing, and exploring SLIP. While not a full
-implemenation of Common LISP, SLIP continues to move in that
+implementation of Common LISP, SLIP continues to move in that
 direction.
 
 A more detailed explanation of some of the features are on the

--- a/code.go
+++ b/code.go
@@ -72,7 +72,7 @@ const (
 	//   0123456789abcdef0123456789abcdef
 	valueMode = "" +
 		".........ak..a.................." + // 0x00
-		"a.Q#..tq()tt,tttttttttttttt;ttt." + // 0x20
+		"a.Q#.ttq()tt,tttttttttttttt;ttt." + // 0x20
 		"@tttttttttttttttttttttttttt...tt" + // 0x40
 		"Btttttttttttttttttttttttttt.P.t." + // 0x60
 		"................................" + // 0x80
@@ -94,7 +94,7 @@ const (
 	//   0123456789abcdef0123456789abcdef
 	tokenMode = "" +
 		".........TT..T.................." + // 0x00
-		"T.......TTaa.aaaaaaaaaaaaaa.aaa." + // 0x20
+		"T....a..TTaa.aaaaaaaaaaaaaa.aaa." + // 0x20
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaa...aa" + // 0x40
 		".aaaaaaaaaaaaaaaaaaaaaaaaaa...a." + // 0x60
 		"................................" + // 0x80

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -3,11 +3,6 @@
 - **multipass** or utm for linux
 
 - next
- - v1.3.1 release with aux.go change
- - update ohler.com
-  - and rss
- - mongodb and ggql plugin release
-  - test to make sure
  - post notice on forums
  - verify goreportcard
 

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -2,10 +2,6 @@
 
 - **multipass** or utm for linux
 
-- next
- - post notice on forums
- - verify goreportcard
-
 ---------------------
 
 - flavor allow out of order defflavor like standard-class
@@ -42,9 +38,6 @@
  - watch.connect.safeEval
   - encode condition and decode
   - frame test broken
-
-
- - structs - seems like a downgrade from class or flavors, just another weaker alternative instances with slots
 
  - package-export
   - import

--- a/test/code_test.go
+++ b/test/code_test.go
@@ -49,6 +49,9 @@ func TestCodeToken(t *testing.T) {
 		{src: "cl:abc", expect: "[cl:abc]", kind: "symbol"},
 		{src: "\nt\n", expect: "[t]", kind: "t"},
 		{src: "@2022-04-10T18:52:17Z", expect: "[@2022-04-10T18:52:17Z]", kind: "time"},
+		{src: "%foo%", expect: "[|%foo%|]", kind: "symbol"},
+		{src: "%cursor-marker%", expect: "[|%cursor-marker%|]", kind: "symbol"},
+		{src: "test%middle", expect: "[|test%middle|]", kind: "symbol"},
 	} {
 		ct.test(t, i)
 	}


### PR DESCRIPTION
## Summary
- Update `valueMode` and `tokenMode` tables to treat `%` (0x25) as a valid character for starting and continuing tokens
- Enables parsing of Common Lisp symbols that use `%` in their names, such as SLIME's `swank::%cursor-marker%` internal symbol
- Add test cases for symbols containing percent signs

## Test plan
- [x] Added test cases for `%foo%`, `%cursor-marker%`, and `test%middle`
- [x] Verified SLIME can connect without parse errors on `%` symbols