### PR TITLE
Handle worktrees and non-standard checkout locations in truename tests

### DIFF
--- a/test/cl/truename_test.go
+++ b/test/cl/truename_test.go
@@ -26,7 +26,7 @@ func validateTruename(t *testing.T, v slip.Object) {
 
 func TestTruenameStringOk(t *testing.T) {
 	(&sliptest.Function{
-		Source: `(truename "truename_test.go")`,
+		Source:   `(truename "truename_test.go")`,
 		Validate: validateTruename,
 	}).Test(t)
 }

--- a/test/cl/truename_test.go
+++ b/test/cl/truename_test.go
@@ -3,16 +3,31 @@
 package cl_test
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/ohler55/ojg/tt"
 	"github.com/ohler55/slip"
 	"github.com/ohler55/slip/sliptest"
 )
 
+func validateTruename(t *testing.T, v slip.Object) {
+	t.Helper()
+
+	s, ok := v.(slip.String)
+	tt.Equal(t, true, ok, "expected truename to return a string, got %T", v)
+
+	path := string(s)
+	tt.Equal(t, true, filepath.IsAbs(path), "expected absolute path, got %q", path)
+	tt.Equal(t, true, strings.HasSuffix(filepath.ToSlash(path), "/test/cl/truename_test.go"),
+		"expected path to end with /test/cl/truename_test.go, got %q", path)
+}
+
 func TestTruenameStringOk(t *testing.T) {
 	(&sliptest.Function{
 		Source: `(truename "truename_test.go")`,
-		Expect: `/.*\/slip\/test\/cl\/truename_test.go/`,
+		Validate: validateTruename,
 	}).Test(t)
 }
 
@@ -32,8 +47,8 @@ func TestTruenameNotFilespec(t *testing.T) {
 
 func TestTruenameFileStream(t *testing.T) {
 	(&sliptest.Function{
-		Source: `(with-open-file (f "truename_test.go" :direction :input) (truename f))`,
-		Expect: `/.*\/slip\/test\/cl\/truename_test.go/`,
+		Source:   `(with-open-file (f "truename_test.go" :direction :input) (truename f))`,
+		Validate: validateTruename,
 	}).Test(t)
 }
 
@@ -46,7 +61,7 @@ func TestTruenameSynonymStreamOk(t *testing.T) {
                   (let ((ss (make-synonym-stream 'zz)))
                    (setq zz f)
                    (truename ss)))`,
-		Expect: `/.*\/slip\/test\/cl\/truename_test.go/`,
+		Validate: validateTruename,
 	}).Test(t)
 }
 


### PR DESCRIPTION
## Summary
  - make truename success tests validate absolute paths instead of a hardcoded checkout layout
  - assert the returned path still ends with test/cl/truename_test.go
  - keep the tests valid for worktrees and non-standard repository locations

  ## Testing
  - go test ./test/cl -run 'TestTruename'