### PR TITLE
Fix lambda closure scope ordering

### DIFF
--- a/lambda.go
+++ b/lambda.go
@@ -29,7 +29,7 @@ type Lambda struct {
 func (lam *Lambda) Call(s *Scope, args List, depth int) (result Object) {
 	ss := s.NewScope()
 	if lam.Closure != nil {
-		ss.parents = append(ss.parents, lam.Closure)
+		ss.parents = append([]*Scope{lam.Closure}, ss.parents...)
 		ss.Macro = lam.Closure.Macro
 	} else if s.Keep { // flavors instance uses this
 		ss.parents = append(ss.parents, s)

--- a/test/lambda_test.go
+++ b/test/lambda_test.go
@@ -87,6 +87,39 @@ func TestLambdaCallInFunc(t *testing.T) {
 	}).Test(t)
 }
 
+func TestLambdaClosureBindingPrecedesCallerScope(t *testing.T) {
+	scope := slip.NewScope()
+	_ = slip.ReadString(`
+(defun closure-shadow-call-with-fn (fn)
+  (funcall fn 0))
+(defun closure-shadow-target (x)
+  t)
+(defun closure-shadow-wrapper (fn)
+  (closure-shadow-call-with-fn
+    (lambda (x) (eq fn (function closure-shadow-target)))))`, scope).Eval(scope, nil)
+	(&sliptest.Function{
+		Scope:  scope,
+		Source: `(closure-shadow-wrapper (function closure-shadow-target))`,
+		Expect: "t",
+	}).Test(t)
+}
+
+func TestLambdaClosurePreservesCallerParentScope(t *testing.T) {
+	scope := slip.NewScope()
+	_ = slip.ReadString(`
+(defun closure-parent-use-extra (fn extra)
+  (funcall fn 0))
+(defun closure-parent-wrapper (fn)
+  (closure-parent-use-extra
+    (lambda (x) (list (eq fn 'lexical) extra))
+    'caller-parent))`, scope).Eval(scope, nil)
+	(&sliptest.Function{
+		Scope:  scope,
+		Source: `(closure-parent-wrapper 'lexical)`,
+		Expect: "(t caller-parent)",
+	}).Test(t)
+}
+
 func TestLambdaCallBadKeyword(t *testing.T) {
 	(&sliptest.Function{
 		Source:    `((lambda (&key :test) test) :test)`,


### PR DESCRIPTION
## Summary
- fix closure-backed lambda calls so captured lexical bindings take precedence over caller-scope bindings
- add a regression for same-named higher-order function parameters shadowing a closure variable

## Verification
- make lint
- make test
- go tool cover -func=test/cov.out => 96.5%