### PR TITLE
Add response writer header setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.4.2] - unreleased
+### Added
+- Added `:header-set` and `:header-add` methods to `http-response-writer-flavor`.
+
 ### Fixed
 - The CompileList function now correctly handles package prefixes.
 - More robust concurrency protection on package access.

--- a/pkg/net/response-writer.go
+++ b/pkg/net/response-writer.go
@@ -27,6 +27,8 @@ func defResponseWriter() *flavors.Flavor {
 	responseWriterFlavor.DefMethod(":write", "", respWriterWriteCaller(true))
 	responseWriterFlavor.DefMethod(":header", "", respWriterHeaderCaller(true))
 	responseWriterFlavor.DefMethod(":header-get", "", respWriterHeaderGetCaller(true))
+	responseWriterFlavor.DefMethod(":header-set", "", respWriterHeaderSetCaller(true))
+	responseWriterFlavor.DefMethod(":header-add", "", respWriterHeaderAddCaller(true))
 
 	return responseWriterFlavor
 }
@@ -128,6 +130,62 @@ func (caller respWriterHeaderGetCaller) Docs() string {
    _key_ for the header value to get
 
 Returns the header of the responseWriter as an association list.
+`
+}
+
+type respWriterHeaderSetCaller bool
+
+func (caller respWriterHeaderSetCaller) Call(s *slip.Scope, args slip.List, depth int) slip.Object {
+	obj := s.Get("self").(*flavors.Instance)
+	if len(args) != 2 {
+		slip.MethodArgChoicePanic(s, depth, obj, ":header-set", len(args), "2")
+	}
+	key, ok := args[0].(slip.String)
+	if !ok {
+		slip.TypePanic(s, depth, "responseWriter :header-set key", args[0], "string")
+	}
+	value, ok := args[1].(slip.String)
+	if !ok {
+		slip.TypePanic(s, depth, "responseWriter :header-set value", args[1], "string")
+	}
+	(obj.Any.(http.ResponseWriter)).Header().Set(string(key), string(value))
+	return nil
+}
+
+func (caller respWriterHeaderSetCaller) Docs() string {
+	return `__:header-set__ _key_ _value_ => _nil_
+   _key_ for the header value to set
+   _value_ to set for the header
+
+Sets the responseWriter header value for _key_ to _value_.
+`
+}
+
+type respWriterHeaderAddCaller bool
+
+func (caller respWriterHeaderAddCaller) Call(s *slip.Scope, args slip.List, depth int) slip.Object {
+	obj := s.Get("self").(*flavors.Instance)
+	if len(args) != 2 {
+		slip.MethodArgChoicePanic(s, depth, obj, ":header-add", len(args), "2")
+	}
+	key, ok := args[0].(slip.String)
+	if !ok {
+		slip.TypePanic(s, depth, "responseWriter :header-add key", args[0], "string")
+	}
+	value, ok := args[1].(slip.String)
+	if !ok {
+		slip.TypePanic(s, depth, "responseWriter :header-add value", args[1], "string")
+	}
+	(obj.Any.(http.ResponseWriter)).Header().Add(string(key), string(value))
+	return nil
+}
+
+func (caller respWriterHeaderAddCaller) Docs() string {
+	return `__:header-add__ _key_ _value_ => _nil_
+   _key_ for the header value to add
+   _value_ to add to the header
+
+Adds _value_ to the responseWriter header values for _key_.
 `
 }
 

--- a/test/net/response-writer_test.go
+++ b/test/net/response-writer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ohler55/ojg/tt"
 	"github.com/ohler55/slip"
 	"github.com/ohler55/slip/pkg/flavors"
+	slipnet "github.com/ohler55/slip/pkg/net"
 	"github.com/ohler55/slip/sliptest"
 )
 
@@ -35,6 +36,13 @@ func (rw *respWriter) Write(b []byte) (int, error) {
 
 func (rw *respWriter) WriteHeader(code int) {
 	rw.code = code
+}
+
+func TestMakeResponseWriter(t *testing.T) {
+	rw := &respWriter{header: http.Header{}}
+	inst := slipnet.MakeResponseWriter(rw)
+	tt.Equal(t, rw, inst.Any)
+	tt.Equal(t, "http-response-writer-flavor", inst.Type.Name())
 }
 
 func TestResponseWriterMethods(t *testing.T) {

--- a/test/net/response-writer_test.go
+++ b/test/net/response-writer_test.go
@@ -61,6 +61,28 @@ func TestResponseWriterMethods(t *testing.T) {
 	}).Test(t)
 	(&sliptest.Function{
 		Scope:  scope,
+		Source: `(send rw :header-set "Content-Type" "application/json")`,
+		Expect: "nil",
+	}).Test(t)
+	tt.Equal(t, "application/json", rw.header.Get("Content-Type"))
+	(&sliptest.Function{
+		Scope:  scope,
+		Source: `(send rw :header-get "Content-Type")`,
+		Expect: `"application/json"`,
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:  scope,
+		Source: `(send rw :header-add "Vary" "Accept-Encoding")`,
+		Expect: "nil",
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:  scope,
+		Source: `(send rw :header-add "Vary" "Origin")`,
+		Expect: "nil",
+	}).Test(t)
+	tt.Equal(t, []string{"Accept-Encoding", "Origin"}, rw.header["Vary"])
+	(&sliptest.Function{
+		Scope:  scope,
 		Source: `(send rw :write-status 201)`,
 		Expect: "nil",
 	}).Test(t)
@@ -86,6 +108,16 @@ func TestResponseWriterDocs(t *testing.T) {
 	_ = slip.ReadString(`(describe-method http-response-writer-flavor :header-get out)`, scope).Eval(scope, nil)
 	str = out.String()
 	tt.Equal(t, true, strings.Contains(str, ":header-get"))
+
+	out.Reset()
+	_ = slip.ReadString(`(describe-method http-response-writer-flavor :header-set out)`, scope).Eval(scope, nil)
+	str = out.String()
+	tt.Equal(t, true, strings.Contains(str, ":header-set"))
+
+	out.Reset()
+	_ = slip.ReadString(`(describe-method http-response-writer-flavor :header-add out)`, scope).Eval(scope, nil)
+	str = out.String()
+	tt.Equal(t, true, strings.Contains(str, ":header-add"))
 
 	out.Reset()
 	_ = slip.ReadString(`(describe-method http-response-writer-flavor :write-status out)`, scope).Eval(scope, nil)
@@ -119,6 +151,48 @@ func TestResponseWriterMethodPanics(t *testing.T) {
 	(&sliptest.Function{
 		Scope:     scope,
 		Source:    `(send rw :header-get t)`,
+		PanicType: slip.Symbol("type-error"),
+	}).Test(t)
+
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-set)`,
+		PanicType: slip.Symbol("error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-set "Content-Type")`,
+		PanicType: slip.Symbol("error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-set t "application/json")`,
+		PanicType: slip.Symbol("type-error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-set "Content-Type" t)`,
+		PanicType: slip.Symbol("type-error"),
+	}).Test(t)
+
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-add)`,
+		PanicType: slip.Symbol("error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-add "Vary")`,
+		PanicType: slip.Symbol("error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-add t "Origin")`,
+		PanicType: slip.Symbol("type-error"),
+	}).Test(t)
+	(&sliptest.Function{
+		Scope:     scope,
+		Source:    `(send rw :header-add "Vary" t)`,
 		PanicType: slip.Symbol("type-error"),
 	}).Test(t)
 


### PR DESCRIPTION
## Summary
- add :header-set and :header-add methods to http-response-writer-flavor
- cover setting, appending, docs, arg-count/type errors, and MakeResponseWriter construction

## Verification
- make lint
- make test
- final combined coverage: 96.7%